### PR TITLE
Add vault kernel runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+STRIPE_KEY=your_stripe_key_here
+KERNEL_KEY=your_kernel_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules/
 backups/
 temp/
-logs/ 
+logs/
+vaults/
+loop_log.json

--- a/engine/DocumentGenerator.js
+++ b/engine/DocumentGenerator.js
@@ -1,0 +1,29 @@
+// DocumentGenerator - converts chat logs into markdown vault files
+const fs = require('fs');
+const path = require('path');
+const ensureFileAndDir = require('../KERNEL_SLATE/shared/utils/ensureFileAndDir');
+
+function parseChat(chatText) {
+  const lines = chatText.split(/\r?\n/).filter(Boolean);
+  const systemIntent = lines[0] || '';
+  return { systemIntent, fullText: chatText };
+}
+
+function generateDocs(parsed, outDir) {
+  const files = [];
+  ensureFileAndDir(path.join(outDir, 'SystemIntent.md'));
+  fs.writeFileSync(path.join(outDir, 'SystemIntent.md'), `# System Intent\n\n${parsed.systemIntent}\n`);
+  files.push(path.join(outDir, 'SystemIntent.md'));
+
+  ensureFileAndDir(path.join(outDir, 'T01_LoopRunner.md'));
+  fs.writeFileSync(path.join(outDir, 'T01_LoopRunner.md'), parsed.fullText);
+  files.push(path.join(outDir, 'T01_LoopRunner.md'));
+
+  ensureFileAndDir(path.join(outDir, 'README.md'));
+  fs.writeFileSync(path.join(outDir, 'README.md'), '# Vault Build\nGenerated from chat log.');
+  files.push(path.join(outDir, 'README.md'));
+
+  return files;
+}
+
+module.exports = { parseChat, generateDocs };

--- a/engine/LoopRunner.js
+++ b/engine/LoopRunner.js
@@ -1,0 +1,76 @@
+// LoopRunner - orchestrates vault generation loops
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { parseChat, generateDocs } = require('./DocumentGenerator');
+const ensureFileAndDir = require('../KERNEL_SLATE/shared/utils/ensureFileAndDir');
+const { execSync } = require('child_process');
+
+const INPUT_FILE = process.env.INPUT_FILE || path.resolve('input/seed_chatlog.txt');
+const VAULT_DIR = path.resolve('vaults/vault_kernel_build');
+const LOOP_LOG = path.resolve('loop_log.json');
+
+function loadLoopLog() {
+  if (!fs.existsSync(LOOP_LOG)) {
+    ensureFileAndDir(LOOP_LOG, '[]');
+  }
+  try {
+    return JSON.parse(fs.readFileSync(LOOP_LOG, 'utf-8'));
+  } catch {
+    return [];
+  }
+}
+
+function saveLoopLog(log) {
+  ensureFileAndDir(LOOP_LOG);
+  fs.writeFileSync(LOOP_LOG, JSON.stringify(log, null, 2));
+}
+
+function generateLoopId() {
+  const h = crypto.createHash('sha256');
+  h.update(Date.now().toString());
+  return h.digest('hex').slice(0, 8);
+}
+
+async function run() {
+  const loopId = generateLoopId();
+  const timestamp = new Date().toISOString();
+  const logEntry = { id: loopId, timestamp, origin: INPUT_FILE, files: [], success: false };
+  const log = loadLoopLog();
+
+  try {
+    if (!fs.existsSync(INPUT_FILE)) throw new Error('Input file missing');
+    const chat = fs.readFileSync(INPUT_FILE, 'utf-8');
+    const parsed = parseChat(chat);
+    const outDir = VAULT_DIR;
+    fs.mkdirSync(outDir, { recursive: true });
+    const files = generateDocs(parsed, outDir);
+    logEntry.files = files.map(f => path.relative('.', f));
+    // Create export zip if zip command is available
+    try {
+      execSync(`zip -r ${path.join(outDir, 'export.zip')} .`, { cwd: outDir });
+      logEntry.files.push(path.relative('.', path.join(outDir, 'export.zip')));
+    } catch (zipErr) {
+      console.error('Zip step failed:', zipErr.message);
+    }
+    logEntry.success = true;
+  } catch (err) {
+    logEntry.error = err.message;
+    console.error('Loop failed:', err.message);
+  }
+
+  log.push(logEntry);
+  saveLoopLog(log);
+
+  if (logEntry.success) {
+    console.log('Loop complete:', loopId);
+  } else {
+    console.log('Loop failed:', loopId);
+  }
+}
+
+if (require.main === module) {
+  run();
+}
+
+module.exports = { run };

--- a/input/seed_chatlog.txt
+++ b/input/seed_chatlog.txt
@@ -1,0 +1,1 @@
+Hello world. This is a sample chat log for the vault kernel build.

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+node engine/LoopRunner.js


### PR DESCRIPTION
## Summary
- implement initial LoopRunner and DocumentGenerator modules for vault-building loops
- add run.sh CLI launcher
- include sample input chat log and example environment variables
- ignore vault outputs and loop logs

## Testing
- `npm test` *(fails: jest not found)*
- `./run.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849e4199cec832797c2fce3a646cf22